### PR TITLE
Fix decryption check to show empty strings

### DIFF
--- a/secure_data_encryption.py
+++ b/secure_data_encryption.py
@@ -122,7 +122,7 @@ def main():
             sys.exit(1)
 
         decrypted = decrypt(b64_encrypted_data, password)
-        if decrypted:
+        if decrypted is not None:
             print("\nDecrypted data:")
             print(decrypted)
 


### PR DESCRIPTION
## Summary
- allow empty strings to be shown after decryption

## Testing
- `python -m py_compile secure_data_encryption.py`
